### PR TITLE
土日に本日のごみの種類画面が表示されない点の修正

### DIFF
--- a/front/components/BottomTabs.tsx
+++ b/front/components/BottomTabs.tsx
@@ -39,7 +39,11 @@ export const BottomTabs = () => {
         name='TodayTrash'
         component={TodayTrash}
         options={{
-          title: '本日のごみの種類',
+          title: new Date().getDay() === 6
+            ? '明後日の収集物'
+            : new Date().getDay() === 0
+              ? '明日の収集物'
+              : '本日の収集物',
           headerLeft: () => null,
         }}
       />
@@ -47,7 +51,7 @@ export const BottomTabs = () => {
         name='Calendar'
         component={TrashCalendar}
         options={{
-          title: 'ごみカレンダー',
+          title: 'カレンダー',
         }}
       />
       <Tab.Screen

--- a/front/pages/Calendar.tsx
+++ b/front/pages/Calendar.tsx
@@ -44,7 +44,7 @@ export const TrashCalendar = () => {
   });
 
   const thieYear = new Date().getFullYear();
-  const thisMonth = Number(new Date().getMonth()) + 1;
+  const thisMonth = new Date().getMonth() + 1;
 
   const header = () => {
     return (
@@ -110,6 +110,7 @@ export const TrashCalendar = () => {
         bodyContainerStyle={{
           backgroundColor: 'white',
         }}
+        swipeEnabled={false}
       />
     </Box>
   );

--- a/front/pages/TodayTrash.tsx
+++ b/front/pages/TodayTrash.tsx
@@ -50,13 +50,28 @@ export const TodayTrash = () => {
   );
 
   const year = new Date().getFullYear();
-  const month = Number(new Date().getMonth()) + 1;
+  const month = new Date().getMonth();
   const day = new Date().getDate();
 
-  const today =
-    year + '-' + month.toString().padStart(2, '0') + '-' + day.toString().padStart(2, '0');
+  const today = new Date(year, month, day, 9);
+  const tomorrow = new Date(year, month, day, 9);
+  const dayAfterTomorrow = new Date(year, month, day, 9);
 
-  const todayTrash = trashes?.find((t) => t.date.toString() === today);
+  tomorrow.setDate(today.getDate() + 1);
+  dayAfterTomorrow.setDate(tomorrow.getDate() + 1);
+
+  const searchDate = (trash: Trash) => {
+    switch (new Date(trash.date).getTime()) {
+      case today.getTime():
+      case tomorrow.getTime():
+      case dayAfterTomorrow.getTime():
+        return trash;
+      default:
+        return null;
+    }
+  };
+
+  const todayTrash = trashes?.find((t) => searchDate(t));
 
   const changeColor = (title: TrashName) => {
     switch (title) {


### PR DESCRIPTION
## 概要
- 土日には月曜日のごみの種類が表示されるよう変更
- ページタイトル変更
- カレンダースワイプのオフ